### PR TITLE
Add a method to send Command in `CockpitConnector`

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
+++ b/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
@@ -15,11 +15,17 @@
  */
 package io.gravitee.cockpit.api;
 
+import io.gravitee.cockpit.api.command.Command;
+import io.gravitee.cockpit.api.command.Payload;
+import io.gravitee.cockpit.api.command.Reply;
 import io.gravitee.common.service.Service;
+import io.reactivex.Maybe;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface CockpitConnector  extends Service<CockpitConnector> {
+public interface CockpitConnector extends Service<CockpitConnector> {
+
+    Maybe<Reply> sendCommand(Command<? extends Payload> command);
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/Command.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Command.java
@@ -16,6 +16,7 @@
 package io.gravitee.cockpit.api.command;
 
 import com.fasterxml.jackson.annotation.*;
+import io.gravitee.cockpit.api.command.echo.EchoCommand;
 import io.gravitee.cockpit.api.command.environment.EnvironmentCommand;
 import io.gravitee.cockpit.api.command.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.installation.InstallationCommand;
@@ -38,7 +39,8 @@ import io.gravitee.common.utils.UUID;
         @JsonSubTypes.Type(value = UserCommand.class, name = "USER_COMMAND"),
         @JsonSubTypes.Type(value = MembershipCommand.class, name = "MEMBERSHIP_COMMAND"),
         @JsonSubTypes.Type(value = InstallationCommand.class, name = "INSTALLATION_COMMAND"),
-        @JsonSubTypes.Type(value = HelloCommand.class, name = "HELLO_COMMAND")}
+        @JsonSubTypes.Type(value = HelloCommand.class, name = "HELLO_COMMAND"),
+        @JsonSubTypes.Type(value = EchoCommand.class, name = "ECHO_COMMAND")}
 )
 public abstract class Command<T extends Payload> {
 
@@ -53,7 +55,13 @@ public abstract class Command<T extends Payload> {
     protected Type type;
 
     public enum Type {
-        ORGANIZATION_COMMAND, ENVIRONMENT_COMMAND, HELLO_COMMAND, USER_COMMAND, MEMBERSHIP_COMMAND, INSTALLATION_COMMAND
+        ORGANIZATION_COMMAND,
+        ENVIRONMENT_COMMAND,
+        HELLO_COMMAND,
+        USER_COMMAND,
+        MEMBERSHIP_COMMAND,
+        INSTALLATION_COMMAND,
+        ECHO_COMMAND
     }
 
     public Command(Type type) {

--- a/src/main/java/io/gravitee/cockpit/api/command/Reply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Reply.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.cockpit.api.command.echo.EchoReply;
 import io.gravitee.cockpit.api.command.environment.EnvironmentReply;
 import io.gravitee.cockpit.api.command.hello.HelloReply;
 import io.gravitee.cockpit.api.command.ignored.IgnoredReply;
@@ -43,13 +44,21 @@ import io.gravitee.cockpit.api.command.user.UserReply;
         @JsonSubTypes.Type(value = MembershipReply.class, name = "MEMBERSHIP_REPLY"),
         @JsonSubTypes.Type(value = InstallationReply.class, name = "INSTALLATION_REPLY"),
         @JsonSubTypes.Type(value = HelloReply.class, name = "HELLO_REPLY"),
+        @JsonSubTypes.Type(value = EchoReply.class, name = "ECHO_REPLY"),
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class Reply {
 
      public enum Type {
-          IGNORED_REPLY, ORGANIZATION_REPLY, ENVIRONMENT_REPLY, HELLO_REPLY, USER_REPLY, MEMBERSHIP_REPLY, INSTALLATION_REPLY
+          IGNORED_REPLY,
+          ORGANIZATION_REPLY,
+          ENVIRONMENT_REPLY,
+          HELLO_REPLY,
+          USER_REPLY,
+          MEMBERSHIP_REPLY,
+          INSTALLATION_REPLY,
+          ECHO_REPLY
      }
 
      protected String commandId;

--- a/src/main/java/io/gravitee/cockpit/api/command/echo/EchoCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/echo/EchoCommand.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.echo;
+
+import io.gravitee.cockpit.api.command.Command;
+
+public class EchoCommand extends Command<EchoPayload> {
+    public EchoCommand() {
+        super(Type.ECHO_COMMAND);
+    }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/echo/EchoPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/echo/EchoPayload.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.echo;
+
+import io.gravitee.cockpit.api.command.Payload;
+
+import java.util.Map;
+
+public class EchoPayload implements Payload {
+
+    private Map<String, String> content;
+
+    public Map<String, String> getContent() {
+        return content;
+    }
+
+    public void setContent(Map<String, String> content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/echo/EchoReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/echo/EchoReply.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.echo;
+
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.Reply;
+
+import java.util.Map;
+
+public class EchoReply extends Reply {
+
+    private Map<String, String> content;
+
+    public EchoReply() {
+        super(Type.ECHO_REPLY);
+    }
+
+    public EchoReply(String commandId, CommandStatus commandStatus) {
+        super(Type.ECHO_REPLY, commandId, commandStatus);
+    }
+
+    public Map<String, String> getContent() {
+        return content;
+    }
+
+    public void setContent(Map<String, String> content) {
+        this.content = content;
+    }
+}


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/gravitee-cockpit/issues/323

**Description**

 - Added an echo command for test purpose
 - Add a `sendCommand` method in `CockpitConnector` like it's done in `CockpitController` (see https://github.com/gravitee-io/gravitee-cockpit/blob/542ea6061bc6028b3ba625e2c74601ae9f4e6db2/gravitee-cockpit-controller/gravitee-cockpit-controller-api/src/main/java/com/graviteesource/cockpit/controller/api/CockpitController.java#L15)