### PR TITLE
Command: Introduce an UnknownCommand 

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/Command.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Command.java
@@ -28,6 +28,7 @@ import io.gravitee.cockpit.api.command.membership.DeleteMembershipCommand;
 import io.gravitee.cockpit.api.command.membership.MembershipCommand;
 import io.gravitee.cockpit.api.command.node.NodeCommand;
 import io.gravitee.cockpit.api.command.organization.OrganizationCommand;
+import io.gravitee.cockpit.api.command.unknown.UnknownCommand;
 import io.gravitee.cockpit.api.command.user.UserCommand;
 import io.gravitee.common.utils.UUID;
 
@@ -39,7 +40,8 @@ import io.gravitee.common.utils.UUID;
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   include = JsonTypeInfo.As.EXISTING_PROPERTY,
-  property = "type"
+  property = "type",
+  defaultImpl = UnknownCommand.class
 )
 @JsonSubTypes(
   {
@@ -87,6 +89,7 @@ public abstract class Command<T extends Payload> {
   protected Type type;
 
   public enum Type {
+    UNKNOWN_COMMAND,
     ORGANIZATION_COMMAND,
     ENVIRONMENT_COMMAND,
     HELLO_COMMAND,

--- a/src/main/java/io/gravitee/cockpit/api/command/unknown/UnknownCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/unknown/UnknownCommand.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.unknown;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.cockpit.api.command.Command;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnknownCommand extends Command<UnknownPayload> {
+
+  public UnknownCommand() {
+    super(Type.UNKNOWN_COMMAND);
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/unknown/UnknownPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/unknown/UnknownPayload.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.unknown;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.gravitee.cockpit.api.command.Payload;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class UnknownPayload implements Payload {}


### PR DESCRIPTION
It is used as a default implementation of `Command` abstract class when parsing JSON to Command with Jackson

The goal is to avoid the following error when receiving a Command that can not be parsed (for instance cockpit send new commands not handled on APIM side yet):
> Caused by: com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve type id 'INSTALLATION_COMMAND' as a subtype of `io.gravitee.cockpit.api.command.Command`: known type ids = [ENVIRONMENT_COMMAND, HELLO_COMMAND, MEMBERSHIP_COMMAND, ORGANIZATION_COMMAND, USER_COMMAND]