### PR TITLE
feat: new AlertTriggerCommand

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <gravitee-node-api.version>1.7.1</gravitee-node-api.version>
+        <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
     </properties>
 
     <dependencies>
@@ -49,6 +50,13 @@
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
             <version>${gravitee-node-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.alert</groupId>
+            <artifactId>gravitee-alert-api</artifactId>
+            <version>${gravitee-alert-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/cockpit/api/command/Command.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Command.java
@@ -18,6 +18,7 @@ package io.gravitee.cockpit.api.command;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.cockpit.api.command.alert.AlertTriggerCommand;
 import io.gravitee.cockpit.api.command.bridge.BridgeCommand;
 import io.gravitee.cockpit.api.command.echo.EchoCommand;
 import io.gravitee.cockpit.api.command.environment.EnvironmentCommand;
@@ -82,6 +83,10 @@ import java.io.Serializable;
       name = "MONITORING_COMMAND"
     ),
     @JsonSubTypes.Type(value = BridgeCommand.class, name = "BRIDGE_COMMAND"),
+    @JsonSubTypes.Type(
+      value = AlertTriggerCommand.class,
+      name = "ALERT_TRIGGER_COMMAND"
+    ),
   }
 )
 public abstract class Command<T extends Payload> implements Serializable {
@@ -114,6 +119,7 @@ public abstract class Command<T extends Payload> implements Serializable {
     HEALTHCHECK_COMMAND,
     MONITORING_COMMAND,
     BRIDGE_COMMAND,
+    ALERT_TRIGGER_COMMAND,
   }
 
   public Command(Type type) {

--- a/src/main/java/io/gravitee/cockpit/api/command/Reply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Reply.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.gravitee.cockpit.api.command.alert.AlertTriggerReply;
 import io.gravitee.cockpit.api.command.bridge.BridgeMultiReply;
 import io.gravitee.cockpit.api.command.bridge.BridgeSimpleReply;
 import io.gravitee.cockpit.api.command.echo.EchoReply;
@@ -89,6 +90,10 @@ import java.io.Serializable;
       value = MonitoringReply.class,
       name = "MONITORING_REPLY"
     ),
+    @JsonSubTypes.Type(
+      value = AlertTriggerReply.class,
+      name = "ALERT_TRIGGER_REPLY"
+    ),
   }
 )
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -111,6 +116,7 @@ public abstract class Reply implements Serializable {
     BRIDGE_SIMPLE_REPLY,
     BRIDGE_MULTI_REPLY,
     MONITORING_REPLY,
+    ALERT_TRIGGER_REPLY,
   }
 
   /**

--- a/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerCommand.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.alert;
+
+import io.gravitee.cockpit.api.command.Command;
+
+/**
+ * @author Lorie Pisicchio (lorie.pisicchio at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertTriggerCommand extends Command<AlertTriggerPayload> {
+
+  public AlertTriggerCommand() {
+    super(Type.ALERT_TRIGGER_COMMAND);
+  }
+
+  public AlertTriggerCommand(AlertTriggerPayload payload) {
+    this();
+    this.payload = payload;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerPayload.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.alert;
+
+import io.gravitee.alert.api.trigger.Trigger;
+import io.gravitee.cockpit.api.command.Payload;
+
+/**
+ * @author Lorie Pisicchio (lorie.pisicchio at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertTriggerPayload implements Payload {
+
+  private Trigger trigger;
+
+  public Trigger getTrigger() {
+    return trigger;
+  }
+
+  public void setTrigger(Trigger trigger) {
+    this.trigger = trigger;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/alert/AlertTriggerReply.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.alert;
+
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.Reply;
+
+/**
+ * @author Lorie Pisicchio (lorie.pisicchio at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class AlertTriggerReply extends Reply {
+
+  public AlertTriggerReply() {
+    this(null, null);
+  }
+
+  public AlertTriggerReply(String commandId, CommandStatus commandStatus) {
+    super(Type.ALERT_TRIGGER_REPLY, commandId, commandStatus);
+  }
+}


### PR DESCRIPTION
Related to https://github.com/gravitee-io/gravitee-cockpit/issues/716

Create a new command for Alert Trigger create / update.

This PR adds a dependency on `gravitee-alert-api`, as the payload of this new command will be a `Trigger`, defined in the alert api.

