### PR TITLE
feat: add constants for installation type

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/hello/HelloPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/hello/HelloPayload.java
@@ -26,6 +26,11 @@ import java.util.Map;
  */
 public class HelloPayload implements Payload {
 
+  public static final String ADDITIONAL_INFO_INSTALLATION_TYPE =
+    "INSTALLATION_TYPE";
+  public static final String TRIAL_INSTALLATION_TYPE = "trial";
+  public static final String ONPREM_INSTALLATION_TYPE = "onprem";
+
   /**
    * Contains all necessary information about the node.
    */


### PR DESCRIPTION
Add constants for installation type. Will be used in APIM & Cockpit
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.11.0-2536-differentiate-trial-installation-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/1.11.0-2536-differentiate-trial-installation-SNAPSHOT/gravitee-cockpit-api-1.11.0-2536-differentiate-trial-installation-SNAPSHOT.zip)
  <!-- Version placeholder end -->
