### PR TITLE
refactor: move to RxJava3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,9 @@
 
     <properties>
         <gravitee-bom.version>2.6</gravitee-bom.version>
-        <gravitee-node-api.version>1.26.0</gravitee-node-api.version>
+        <gravitee-node-api.version>2.0.0-bumpRxJava3-SNAPSHOT</gravitee-node-api.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
+        <rxjava.version>3.1.5</rxjava.version>
     </properties>
 
     <dependencyManagement>
@@ -76,8 +77,9 @@
 
         <!-- Reactive dependencies -->
         <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
+            <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
+            <version>${rxjava.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
+++ b/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
@@ -19,7 +19,7 @@ import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.Payload;
 import io.gravitee.cockpit.api.command.Reply;
 import io.gravitee.common.service.Service;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/main/java/io/gravitee/cockpit/api/command/CommandHandler.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/CommandHandler.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.cockpit.api.command;
 
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/main/java/io/gravitee/cockpit/api/command/CommandProducer.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/CommandProducer.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.cockpit.api.command;
 
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
https://graviteedevops.atlassian.net/browse/COC-49

BREAKING CHANGE: rxJava3 required
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-coc49-rxjava3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.0.0-coc49-rxjava3-SNAPSHOT/gravitee-cockpit-api-2.0.0-coc49-rxjava3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
