### PR TITLE
chore: bump to rxJava3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
   setup_release:
     when:
       matches:
-        pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
         value: << pipeline.git.tag >>
     jobs:
       - gravitee/setup_lib-release-config:
@@ -32,4 +32,4 @@ workflows:
                 - /.*/
             tags:
               only:
-                - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.0.0-alpha.1](https://github.com/gravitee-io/gravitee-cockpit-api/compare/1.13.6...2.0.0-alpha.1) (2022-10-18)
+
+
+### chore
+
+* bump to rxJava3 ([b01868f](https://github.com/gravitee-io/gravitee-cockpit-api/commit/b01868fda084d830ca7edaafa5edbde0752fcabd))
+
+
+### BREAKING CHANGES
+
+* rxJava3 required
+ 
 ## [1.13.8](https://github.com/gravitee-io/gravitee-cockpit-api/compare/1.13.7...1.13.8) (2022-11-21)
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,13 +29,13 @@
 
     <groupId>io.gravitee.cockpit</groupId>
     <artifactId>gravitee-cockpit-api</artifactId>
-    <version>1.13.8</version>
+    <version>2.0.0-alpha.1</version>
 
     <name>Gravitee.io - Cockpit - API</name>
 
     <properties>
         <gravitee-bom.version>2.8</gravitee-bom.version>
-        <gravitee-node-api.version>1.27.3</gravitee-node-api.version>
+        <gravitee-node-api.version>2.0.0-alpha.3</gravitee-node-api.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
     </properties>
 
@@ -76,7 +76,7 @@
 
         <!-- Reactive dependencies -->
         <dependency>
-            <groupId>io.reactivex.rxjava2</groupId>
+            <groupId>io.reactivex.rxjava3</groupId>
             <artifactId>rxjava</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <gravitee-bom.version>2.8</gravitee-bom.version>
-        <gravitee-node-api.version>2.0.0-alpha.3</gravitee-node-api.version>
+        <gravitee-node-api.version>2.0.1</gravitee-node-api.version>
         <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
     </properties>
 

--- a/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
+++ b/src/main/java/io/gravitee/cockpit/api/CockpitConnector.java
@@ -19,7 +19,7 @@ import io.gravitee.cockpit.api.command.Command;
 import io.gravitee.cockpit.api.command.Payload;
 import io.gravitee.cockpit.api.command.Reply;
 import io.gravitee.common.service.Service;
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/main/java/io/gravitee/cockpit/api/command/CommandHandler.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/CommandHandler.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.cockpit.api.command;
 
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)

--- a/src/main/java/io/gravitee/cockpit/api/command/CommandProducer.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/CommandProducer.java
@@ -15,7 +15,7 @@
  */
 package io.gravitee.cockpit.api.command;
 
-import io.reactivex.Single;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)


### PR DESCRIPTION
BREAKING CHANGE: rxJava3 required
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-rxjava3-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.0.0-rxjava3-SNAPSHOT/gravitee-cockpit-api-2.0.0-rxjava3-SNAPSHOT.zip)
  <!-- Version placeholder end -->
