### PR TITLE
feat: update organization command payload to add license

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/organization/OrganizationPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/organization/OrganizationPayload.java
@@ -40,4 +40,6 @@ public class OrganizationPayload implements Payload {
   private String description;
 
   private List<AccessPoint> accessPoints;
+
+  private String license;
 }


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/APIM-3556

## Description

Update organization command payload to provide organization license as base64.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.4.0-apim-3556-update-license-command-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.4.0-apim-3556-update-license-command-SNAPSHOT/gravitee-cockpit-api-2.4.0-apim-3556-update-license-command-SNAPSHOT.zip)
  <!-- Version placeholder end -->
