### PR TITLE
feat: add unlink installation command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.gravitee.cockpit</groupId>
     <artifactId>gravitee-cockpit-api</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0-feat-add-unlink-SNAPSHOT</version>
 
     <name>Gravitee.io - Cockpit - API</name>
 

--- a/src/main/java/io/gravitee/cockpit/api/command/Command.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Command.java
@@ -29,6 +29,7 @@ import io.gravitee.cockpit.api.command.goodbye.GoodbyeCommand;
 import io.gravitee.cockpit.api.command.healthcheck.HealthCheckCommand;
 import io.gravitee.cockpit.api.command.hello.HelloCommand;
 import io.gravitee.cockpit.api.command.installation.InstallationCommand;
+import io.gravitee.cockpit.api.command.installation.UnlinkInstallationCommand;
 import io.gravitee.cockpit.api.command.membership.DeleteMembershipCommand;
 import io.gravitee.cockpit.api.command.membership.MembershipCommand;
 import io.gravitee.cockpit.api.command.monitoring.MonitoringCommand;
@@ -73,6 +74,10 @@ import java.io.Serializable;
     @JsonSubTypes.Type(
       value = InstallationCommand.class,
       name = "INSTALLATION_COMMAND"
+    ),
+    @JsonSubTypes.Type(
+      value = UnlinkInstallationCommand.class,
+      name = "UNLINK_INSTALLATION_COMMAND"
     ),
     @JsonSubTypes.Type(value = HelloCommand.class, name = "HELLO_COMMAND"),
     @JsonSubTypes.Type(value = GoodbyeCommand.class, name = "GOODBYE_COMMAND"),
@@ -131,6 +136,7 @@ public abstract class Command<T extends Payload> implements Serializable {
     MEMBERSHIP_COMMAND,
     DELETE_MEMBERSHIP_COMMAND,
     INSTALLATION_COMMAND,
+    UNLINK_INSTALLATION_COMMAND,
     ECHO_COMMAND,
     NODE_COMMAND,
     HEALTHCHECK_COMMAND,

--- a/src/main/java/io/gravitee/cockpit/api/command/Reply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Reply.java
@@ -32,6 +32,7 @@ import io.gravitee.cockpit.api.command.healthcheck.HealthCheckReply;
 import io.gravitee.cockpit.api.command.hello.HelloReply;
 import io.gravitee.cockpit.api.command.ignored.IgnoredReply;
 import io.gravitee.cockpit.api.command.installation.InstallationReply;
+import io.gravitee.cockpit.api.command.installation.UnlinkInstallationReply;
 import io.gravitee.cockpit.api.command.membership.DeleteMembershipReply;
 import io.gravitee.cockpit.api.command.membership.MembershipReply;
 import io.gravitee.cockpit.api.command.monitoring.MonitoringReply;
@@ -73,6 +74,10 @@ import java.io.Serializable;
     @JsonSubTypes.Type(
       value = InstallationReply.class,
       name = "INSTALLATION_REPLY"
+    ),
+    @JsonSubTypes.Type(
+      value = UnlinkInstallationReply.class,
+      name = "UNLINK_INSTALLATION_REPLY"
     ),
     @JsonSubTypes.Type(value = HelloReply.class, name = "HELLO_REPLY"),
     @JsonSubTypes.Type(value = GoodbyeReply.class, name = "GOODBYE_REPLY"),
@@ -127,6 +132,7 @@ public abstract class Reply implements Serializable {
     MEMBERSHIP_REPLY,
     DELETE_MEMBERSHIP_REPLY,
     INSTALLATION_REPLY,
+    UNLINK_INSTALLATION_REPLY,
     ECHO_REPLY,
     NODE_REPLY,
     HEALTHCHECK_REPLY,

--- a/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationCommand.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.installation;
+
+import io.gravitee.cockpit.api.command.Command;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class UnlinkInstallationCommand
+  extends Command<UnlinkInstallationPayload> {
+
+  public UnlinkInstallationCommand() {
+    super(Type.UNLINK_INSTALLATION_COMMAND);
+  }
+
+  public UnlinkInstallationCommand(UnlinkInstallationPayload payload) {
+    this();
+    this.payload = payload;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationPayload.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.installation;
+
+import io.gravitee.cockpit.api.command.Payload;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class UnlinkInstallationPayload implements Payload {
+
+  private String environmentCockpitId;
+
+  private String organizationCockpitId;
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/installation/UnlinkInstallationReply.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.installation;
+
+import io.gravitee.cockpit.api.command.CommandStatus;
+import io.gravitee.cockpit.api.command.Reply;
+
+public class UnlinkInstallationReply extends Reply {
+
+  public UnlinkInstallationReply() {
+    this(null, null);
+  }
+
+  public UnlinkInstallationReply(
+    String commandId,
+    CommandStatus commandStatus
+  ) {
+    super(Type.UNLINK_INSTALLATION_REPLY, commandId, commandStatus);
+  }
+}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-3590

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.5.0-feat-add-unlink-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.5.0-feat-add-unlink-SNAPSHOT/gravitee-cockpit-api-2.5.0-feat-add-unlink-SNAPSHOT.zip)
  <!-- Version placeholder end -->
