### PR TITLE
feat: add commands to disable environment and organization

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/Command.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Command.java
@@ -24,6 +24,7 @@ import io.gravitee.cockpit.api.command.alert.trigger.list.ListAlertTriggersComma
 import io.gravitee.cockpit.api.command.bridge.BridgeCommand;
 import io.gravitee.cockpit.api.command.designer.DeployModelCommand;
 import io.gravitee.cockpit.api.command.echo.EchoCommand;
+import io.gravitee.cockpit.api.command.environment.DisableEnvironmentCommand;
 import io.gravitee.cockpit.api.command.environment.EnvironmentCommand;
 import io.gravitee.cockpit.api.command.goodbye.GoodbyeCommand;
 import io.gravitee.cockpit.api.command.healthcheck.HealthCheckCommand;
@@ -34,6 +35,7 @@ import io.gravitee.cockpit.api.command.membership.DeleteMembershipCommand;
 import io.gravitee.cockpit.api.command.membership.MembershipCommand;
 import io.gravitee.cockpit.api.command.monitoring.MonitoringCommand;
 import io.gravitee.cockpit.api.command.node.NodeCommand;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationCommand;
 import io.gravitee.cockpit.api.command.organization.OrganizationCommand;
 import io.gravitee.cockpit.api.command.unknown.UnknownCommand;
 import io.gravitee.cockpit.api.command.user.UserCommand;
@@ -59,8 +61,16 @@ import java.io.Serializable;
       name = "ORGANIZATION_COMMAND"
     ),
     @JsonSubTypes.Type(
+      value = DisableOrganizationCommand.class,
+      name = "DISABLE_ORGANIZATION_COMMAND"
+    ),
+    @JsonSubTypes.Type(
       value = EnvironmentCommand.class,
       name = "ENVIRONMENT_COMMAND"
+    ),
+    @JsonSubTypes.Type(
+      value = DisableEnvironmentCommand.class,
+      name = "DISABLE_ENVIRONMENT_COMMAND"
     ),
     @JsonSubTypes.Type(value = UserCommand.class, name = "USER_COMMAND"),
     @JsonSubTypes.Type(
@@ -129,7 +139,9 @@ public abstract class Command<T extends Payload> implements Serializable {
   public enum Type {
     UNKNOWN_COMMAND,
     ORGANIZATION_COMMAND,
+    DISABLE_ORGANIZATION_COMMAND,
     ENVIRONMENT_COMMAND,
+    DISABLE_ENVIRONMENT_COMMAND,
     HELLO_COMMAND,
     GOODBYE_COMMAND,
     USER_COMMAND,

--- a/src/main/java/io/gravitee/cockpit/api/command/Reply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/Reply.java
@@ -26,6 +26,7 @@ import io.gravitee.cockpit.api.command.bridge.BridgeMultiReply;
 import io.gravitee.cockpit.api.command.bridge.BridgeSimpleReply;
 import io.gravitee.cockpit.api.command.designer.DeployModelReply;
 import io.gravitee.cockpit.api.command.echo.EchoReply;
+import io.gravitee.cockpit.api.command.environment.DisableEnvironmentReply;
 import io.gravitee.cockpit.api.command.environment.EnvironmentReply;
 import io.gravitee.cockpit.api.command.goodbye.GoodbyeReply;
 import io.gravitee.cockpit.api.command.healthcheck.HealthCheckReply;
@@ -37,6 +38,7 @@ import io.gravitee.cockpit.api.command.membership.DeleteMembershipReply;
 import io.gravitee.cockpit.api.command.membership.MembershipReply;
 import io.gravitee.cockpit.api.command.monitoring.MonitoringReply;
 import io.gravitee.cockpit.api.command.node.NodeReply;
+import io.gravitee.cockpit.api.command.organization.DisableOrganizationReply;
 import io.gravitee.cockpit.api.command.organization.OrganizationReply;
 import io.gravitee.cockpit.api.command.user.UserReply;
 import io.gravitee.cockpit.api.command.v4api.V4ApiReply;
@@ -58,9 +60,18 @@ import java.io.Serializable;
       value = OrganizationReply.class,
       name = "ORGANIZATION_REPLY"
     ),
+    @JsonSubTypes.Type(value = IgnoredReply.class, name = "IGNORED_REPLY"),
+    @JsonSubTypes.Type(
+      value = DisableOrganizationReply.class,
+      name = "DISABLE_ORGANIZATION_REPLY"
+    ),
     @JsonSubTypes.Type(
       value = EnvironmentReply.class,
       name = "ENVIRONMENT_REPLY"
+    ),
+    @JsonSubTypes.Type(
+      value = DisableEnvironmentReply.class,
+      name = "DISABLE_ENVIRONMENT_REPLY"
     ),
     @JsonSubTypes.Type(value = UserReply.class, name = "USER_REPLY"),
     @JsonSubTypes.Type(
@@ -125,7 +136,9 @@ public abstract class Reply implements Serializable {
   public enum Type {
     IGNORED_REPLY,
     ORGANIZATION_REPLY,
+    DISABLE_ORGANIZATION_REPLY,
     ENVIRONMENT_REPLY,
+    DISABLE_ENVIRONMENT_REPLY,
     HELLO_REPLY,
     GOODBYE_REPLY,
     USER_REPLY,

--- a/src/main/java/io/gravitee/cockpit/api/command/accesspoint/AccessPoint.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/accesspoint/AccessPoint.java
@@ -19,11 +19,7 @@ import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)

--- a/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentCommand.java
@@ -15,20 +15,17 @@
  */
 package io.gravitee.cockpit.api.command.environment;
 
-import io.gravitee.cockpit.api.command.CommandStatus;
-import io.gravitee.cockpit.api.command.Reply;
+import io.gravitee.cockpit.api.command.Command;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+public class DisableEnvironmentCommand
+  extends Command<DisableEnvironmentPayload> {
 
-  public EnvironmentReply() {
-    this(null, null);
+  public DisableEnvironmentCommand() {
+    super(Type.DISABLE_ENVIRONMENT_COMMAND);
   }
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
+  public DisableEnvironmentCommand(DisableEnvironmentPayload payload) {
+    this();
+    this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentPayload.java
@@ -15,20 +15,20 @@
  */
 package io.gravitee.cockpit.api.command.environment;
 
-import io.gravitee.cockpit.api.command.CommandStatus;
-import io.gravitee.cockpit.api.command.Reply;
+import io.gravitee.cockpit.api.command.Payload;
+import lombok.*;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DisableEnvironmentPayload implements Payload {
 
-  public EnvironmentReply() {
-    this(null, null);
-  }
+  private String id;
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
-  }
+  private String cockpitId;
+
+  private String name;
+
+  private String userId;
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/environment/DisableEnvironmentReply.java
@@ -18,17 +18,16 @@ package io.gravitee.cockpit.api.command.environment;
 import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.Reply;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+public class DisableEnvironmentReply extends Reply {
 
-  public EnvironmentReply() {
+  public DisableEnvironmentReply() {
     this(null, null);
   }
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
+  public DisableEnvironmentReply(
+    String commandId,
+    CommandStatus commandStatus
+  ) {
+    super(Type.DISABLE_ENVIRONMENT_REPLY, commandId, commandStatus);
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationCommand.java
@@ -13,22 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.environment;
+package io.gravitee.cockpit.api.command.organization;
 
-import io.gravitee.cockpit.api.command.CommandStatus;
-import io.gravitee.cockpit.api.command.Reply;
+import io.gravitee.cockpit.api.command.Command;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+public class DisableOrganizationCommand
+  extends Command<DisableOrganizationPayload> {
 
-  public EnvironmentReply() {
-    this(null, null);
+  public DisableOrganizationCommand() {
+    super(Type.DISABLE_ORGANIZATION_COMMAND);
   }
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
+  public DisableOrganizationCommand(DisableOrganizationPayload payload) {
+    this();
+    this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationPayload.java
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.environment;
+package io.gravitee.cockpit.api.command.organization;
 
-import io.gravitee.cockpit.api.command.CommandStatus;
-import io.gravitee.cockpit.api.command.Reply;
+import io.gravitee.cockpit.api.command.Payload;
+import lombok.*;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DisableOrganizationPayload implements Payload {
 
-  public EnvironmentReply() {
-    this(null, null);
-  }
+  private String id;
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
-  }
+  private String cockpitId;
+
+  private String name;
+
+  private String userId;
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/organization/DisableOrganizationReply.java
@@ -13,22 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.environment;
+package io.gravitee.cockpit.api.command.organization;
 
 import io.gravitee.cockpit.api.command.CommandStatus;
 import io.gravitee.cockpit.api.command.Reply;
 
-/**
- * @author Jeoffrey HAEYAERT (jeoffrey.haeyaert at graviteesource.com)
- * @author GraviteeSource Team
- */
-public class EnvironmentReply extends Reply {
+public class DisableOrganizationReply extends Reply {
 
-  public EnvironmentReply() {
+  public DisableOrganizationReply() {
     this(null, null);
   }
 
-  public EnvironmentReply(String commandId, CommandStatus commandStatus) {
-    super(Type.ENVIRONMENT_REPLY, commandId, commandStatus);
+  public DisableOrganizationReply(
+    String commandId,
+    CommandStatus commandStatus
+  ) {
+    super(Type.DISABLE_ORGANIZATION_REPLY, commandId, commandStatus);
   }
 }


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/CJ-996

**Description**

Add two new commands to handle disabling Environments and Organizations
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.0-cj-996-add-disable-commands-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.6.0-cj-996-add-disable-commands-SNAPSHOT/gravitee-cockpit-api-2.6.0-cj-996-add-disable-commands-SNAPSHOT.zip)
  <!-- Version placeholder end -->
