### PR TITLE
fix(deps): upgrade gravitee dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,9 +34,9 @@
     <name>Gravitee.io - Cockpit - API</name>
 
     <properties>
-        <gravitee-bom.version>2.8</gravitee-bom.version>
-        <gravitee-node-api.version>2.0.1</gravitee-node-api.version>
-        <gravitee-alert-api.version>1.9.1</gravitee-alert-api.version>
+        <gravitee-bom.version>7.0.10</gravitee-bom.version>
+        <gravitee-node-api.version>5.8.1</gravitee-node-api.version>
+        <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Upgrade all gravitee dependencies to their latest versions
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.6.1-chore-upgrade-gravitee-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/2.6.1-chore-upgrade-gravitee-deps-SNAPSHOT/gravitee-cockpit-api-2.6.1-chore-upgrade-gravitee-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
