### PR TITLE
fix: use latest exchange framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>7.0.14</gravitee-bom.version>
         <gravitee-node.version>5.10.0</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-exchange.version>1.0.0</gravitee-exchange.version>
+        <gravitee-exchange.version>1.0.1</gravitee-exchange.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.2-bump-exchange-framework-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.2-bump-exchange-framework-SNAPSHOT/gravitee-cockpit-api-3.0.2-bump-exchange-framework-SNAPSHOT.zip)
  <!-- Version placeholder end -->
