### PR TITLE
fix: add missing command id when adapting legacy to v1

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommand.java
@@ -68,8 +68,9 @@ public class BridgeCommand extends CockpitCommand<BridgePayload> {
     super(CockpitCommandType.BRIDGE_COMMAND);
   }
 
-  public BridgeCommand(BridgePayload payload) {
+  public BridgeCommand(final String commandId, final BridgePayload payload) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommandAdapter.java
@@ -38,6 +38,7 @@ public class BridgeCommandAdapter
       BridgeCommandPayload commandPayload = command.getPayload();
 
       BridgeCommand bridgeCommand = new BridgeCommand(
+        command.getId(),
         new BridgePayload(commandPayload.content())
       );
       bridgeCommand.setTarget(commandPayload.target());

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
@@ -44,6 +44,7 @@ public class BridgeLegacyCommandAdapter
         .timeoutMillis(command.getTimeoutMillis())
         .build();
       return new io.gravitee.cockpit.api.command.v1.bridge.BridgeCommand(
+        command.getId(),
         bridgeCommandPayload
       );
     });

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
@@ -40,7 +40,12 @@ public class BridgeLegacyCommandAdapter
         .environmentId(command.getEnvironmentId())
         .operation(command.getOperation())
         .organizationId(command.getOrganizationId())
-        .content(command.getPayload().getContent())
+        .content(
+          command.getPayload() != null
+            ? command.getPayload().getContent()
+            : null
+        )
+        .installationId(command.getInstallationId())
         .timeoutMillis(command.getTimeoutMillis())
         .build();
       return new io.gravitee.cockpit.api.command.v1.bridge.BridgeCommand(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeMultiReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeMultiReply.java
@@ -16,6 +16,7 @@
 package io.gravitee.cockpit.api.command.legacy.bridge;
 
 import io.gravitee.cockpit.api.command.legacy.CockpitReplyType;
+import io.gravitee.exchange.api.command.CommandStatus;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,11 +29,15 @@ public class BridgeMultiReply extends BridgeReply {
   private List<BridgeSimpleReply> replies;
 
   public BridgeMultiReply() {
-    this(new ArrayList<>());
+    this(null, null, new ArrayList<>());
   }
 
-  public BridgeMultiReply(List<BridgeSimpleReply> replies) {
-    super(CockpitReplyType.BRIDGE_MULTI_REPLY);
+  public BridgeMultiReply(
+    final String commandId,
+    final CommandStatus commandStatus,
+    final List<BridgeSimpleReply> replies
+  ) {
+    super(CockpitReplyType.BRIDGE_MULTI_REPLY, commandId, commandStatus);
     this.replies = replies;
   }
 

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReply.java
@@ -26,14 +26,14 @@ import io.gravitee.exchange.api.command.Payload;
  */
 public abstract class BridgeReply extends CockpitReply<Payload> {
 
-  protected BridgeReply(CockpitReplyType type) {
+  protected BridgeReply(final CockpitReplyType type) {
     this(type, null, null);
   }
 
   protected BridgeReply(
-    CockpitReplyType type,
-    String commandId,
-    CommandStatus commandStatus
+    final CockpitReplyType type,
+    final String commandId,
+    final CommandStatus commandStatus
   ) {
     super(type, commandId, commandStatus);
   }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
@@ -49,7 +49,11 @@ public class BridgeReplyAdapter
               createSimpleReplyFrom(reply, bridgeReplyContent)
             )
             .toList();
-          return new BridgeMultiReply(simpleReplies);
+          return new BridgeMultiReply(
+            reply.getCommandId(),
+            reply.getCommandStatus(),
+            simpleReplies
+          );
         }
       }
       return new BridgeSimpleReply(
@@ -69,9 +73,10 @@ public class BridgeReplyAdapter
       reply.getCommandStatus(),
       reply.getErrorDetails()
     );
-    bridgeSimpleReply.setEnvironmentId(bridgeReplyContent.environmentId());
-    bridgeSimpleReply.setOrganizationId(bridgeReplyContent.organizationId());
-    bridgeSimpleReply.setPayloadAsString(bridgeReplyContent.content());
+    bridgeSimpleReply.setInstallationId(bridgeReplyContent.getInstallationId());
+    bridgeSimpleReply.setEnvironmentId(bridgeReplyContent.getEnvironmentId());
+    bridgeSimpleReply.setOrganizationId(bridgeReplyContent.getOrganizationId());
+    bridgeSimpleReply.setPayloadAsString(bridgeReplyContent.getContent());
     return bridgeSimpleReply;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommand.java
@@ -26,8 +26,12 @@ public class DeployModelCommand
     super(CockpitCommandType.DEPLOY_MODEL_COMMAND);
   }
 
-  public DeployModelCommand(DeployModelCommandPayload payload) {
+  public DeployModelCommand(
+    final String commandId,
+    final DeployModelCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommandAdapter.java
@@ -32,6 +32,8 @@ public class DeployModelCommandAdapter
   public Single<DeployModelCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.designer.DeployModelCommand command
   ) {
-    return Single.just(new DeployModelCommand(command.getPayload()));
+    return Single.just(
+      new DeployModelCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommand.java
@@ -30,8 +30,12 @@ public class DisableEnvironmentCommand
     super(CockpitCommandType.DISABLE_ENVIRONMENT_COMMAND);
   }
 
-  public DisableEnvironmentCommand(DisableEnvironmentCommandPayload payload) {
+  public DisableEnvironmentCommand(
+    final String commandId,
+    final DisableEnvironmentCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommandAdapter.java
@@ -32,6 +32,8 @@ public class DisableEnvironmentCommandAdapter
   public Single<DisableEnvironmentCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.environment.DisableEnvironmentCommand command
   ) {
-    return Single.just(new DisableEnvironmentCommand(command.getPayload()));
+    return Single.just(
+      new DisableEnvironmentCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommand.java
@@ -30,8 +30,12 @@ public class EnvironmentCommand
     super(CockpitCommandType.ENVIRONMENT_COMMAND);
   }
 
-  public EnvironmentCommand(EnvironmentCommandPayload payload) {
+  public EnvironmentCommand(
+    final String commandId,
+    final EnvironmentCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommandAdapter.java
@@ -32,6 +32,8 @@ public class EnvironmentCommandAdapter
   public Single<EnvironmentCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand command
   ) {
-    return Single.just(new EnvironmentCommand(command.getPayload()));
+    return Single.just(
+      new EnvironmentCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommand.java
@@ -26,7 +26,8 @@ import io.gravitee.cockpit.api.command.v1.node.healthcheck.NodeHealthCheckComman
 public class HealthCheckCommand
   extends CockpitCommand<NodeHealthCheckCommandPayload> {
 
-  public HealthCheckCommand() {
+  public HealthCheckCommand(final String commandId) {
     super(CockpitCommandType.HEALTHCHECK_COMMAND);
+    this.id = commandId;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommandAdapter.java
@@ -34,6 +34,7 @@ public class HealthCheckCommandAdapter
   ) {
     return Single.just(
       new io.gravitee.cockpit.api.command.v1.node.healthcheck.NodeHealthCheckCommand(
+        command.getId(),
         command.getPayload()
       )
     );

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommand.java
@@ -29,8 +29,12 @@ public class HelloCommand extends CockpitCommand<HelloCommandPayload> {
     super(CockpitCommandType.HELLO_COMMAND);
   }
 
-  public HelloCommand(HelloCommandPayload payload) {
+  public HelloCommand(
+    final String commandId,
+    final HelloCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommandAdapter.java
@@ -36,6 +36,7 @@ public class HelloCommandAdapter
     return Single.fromCallable(() -> {
       HelloCommandPayload legacyPayload = command.getPayload();
       return new io.gravitee.cockpit.api.command.v1.hello.HelloCommand(
+        command.getId(),
         HelloCommandPayload
           .builder()
           .node(legacyPayload.getNode())

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloReplyAdapter.java
@@ -38,16 +38,18 @@ public class HelloReplyAdapter
         reply.getCommandStatus()
       );
       helloReply.setMessage(reply.getErrorDetails());
-      helloReply.setInstallationId(reply.getPayload().getInstallationId());
-      helloReply.setInstallationStatus(
-        reply.getPayload().getInstallationStatus()
-      );
-      helloReply.setDefaultEnvironmentCockpitId(
-        reply.getPayload().getDefaultEnvironmentCockpitId()
-      );
-      helloReply.setDefaultOrganizationCockpitId(
-        reply.getPayload().getDefaultOrganizationCockpitId()
-      );
+      if (reply.getPayload() != null) {
+        helloReply.setInstallationId(reply.getPayload().getInstallationId());
+        helloReply.setInstallationStatus(
+          reply.getPayload().getInstallationStatus()
+        );
+        helloReply.setDefaultEnvironmentCockpitId(
+          reply.getPayload().getDefaultEnvironmentCockpitId()
+        );
+        helloReply.setDefaultOrganizationCockpitId(
+          reply.getPayload().getDefaultOrganizationCockpitId()
+        );
+      }
       return helloReply;
     });
   }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommand.java
@@ -30,8 +30,12 @@ public class InstallationCommand
     super(CockpitCommandType.INSTALLATION_COMMAND);
   }
 
-  public InstallationCommand(InstallationCommandPayload payload) {
+  public InstallationCommand(
+    final String commandId,
+    final InstallationCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommandAdapter.java
@@ -32,6 +32,8 @@ public class InstallationCommandAdapter
   public Single<InstallationCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.installation.InstallationCommand command
   ) {
-    return Single.just(new InstallationCommand(command.getPayload()));
+    return Single.just(
+      new InstallationCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommand.java
@@ -29,8 +29,12 @@ public class UnlinkInstallationCommand
     super(CockpitCommandType.UNLINK_INSTALLATION_COMMAND);
   }
 
-  public UnlinkInstallationCommand(UnlinkInstallationCommandPayload payload) {
+  public UnlinkInstallationCommand(
+    final String commandId,
+    final UnlinkInstallationCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommandAdapter.java
@@ -32,6 +32,8 @@ public class UnlinkInstallationCommandAdapter
   public Single<UnlinkInstallationCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.installation.UnlinkInstallationCommand command
   ) {
-    return Single.just(new UnlinkInstallationCommand(command.getPayload()));
+    return Single.just(
+      new UnlinkInstallationCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommand.java
@@ -26,8 +26,12 @@ public class DeleteMembershipCommand
     super(CockpitCommandType.DELETE_MEMBERSHIP_COMMAND);
   }
 
-  public DeleteMembershipCommand(DeleteMembershipCommandPayload payload) {
+  public DeleteMembershipCommand(
+    final String commandId,
+    final DeleteMembershipCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommandAdapter.java
@@ -32,6 +32,8 @@ public class DeleteMembershipCommandAdapter
   public Single<DeleteMembershipCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.membership.DeleteMembershipCommand command
   ) {
-    return Single.just(new DeleteMembershipCommand(command.getPayload()));
+    return Single.just(
+      new DeleteMembershipCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommand.java
@@ -30,8 +30,12 @@ public class MembershipCommand
     super(CockpitCommandType.MEMBERSHIP_COMMAND);
   }
 
-  public MembershipCommand(MembershipCommandPayload payload) {
+  public MembershipCommand(
+    final String commandId,
+    final MembershipCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommandAdapter.java
@@ -32,6 +32,8 @@ public class MembershipCommandAdapter
   public Single<MembershipCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.membership.MembershipCommand command
   ) {
-    return Single.just(new MembershipCommand(command.getPayload()));
+    return Single.just(
+      new MembershipCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommand.java
@@ -21,7 +21,8 @@ import io.gravitee.cockpit.api.command.v1.node.NodeCommandPayload;
 
 public class NodeCommand extends CockpitCommand<NodeCommandPayload> {
 
-  public NodeCommand() {
+  public NodeCommand(final String commandId) {
     super(CockpitCommandType.NODE_COMMAND);
+    this.id = commandId;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommandAdapter.java
@@ -34,6 +34,7 @@ public class NodeCommandAdapter
   ) {
     return Single.just(
       new io.gravitee.cockpit.api.command.v1.node.NodeCommand(
+        command.getId(),
         command.getPayload()
       )
     );

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommand.java
@@ -27,8 +27,12 @@ public class DisableOrganizationCommand
     super(CockpitCommandType.DISABLE_ORGANIZATION_COMMAND);
   }
 
-  public DisableOrganizationCommand(DisableOrganizationCommandPayload payload) {
+  public DisableOrganizationCommand(
+    final String commandId,
+    final DisableOrganizationCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommandAdapter.java
@@ -32,6 +32,8 @@ public class DisableOrganizationCommandAdapter
   public Single<DisableOrganizationCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.organization.DisableOrganizationCommand command
   ) {
-    return Single.just(new DisableOrganizationCommand(command.getPayload()));
+    return Single.just(
+      new DisableOrganizationCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommand.java
@@ -30,8 +30,12 @@ public class OrganizationCommand
     super(CockpitCommandType.ORGANIZATION_COMMAND);
   }
 
-  public OrganizationCommand(OrganizationCommandPayload payload) {
+  public OrganizationCommand(
+    final String commandId,
+    final OrganizationCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommandAdapter.java
@@ -32,6 +32,8 @@ public class OrganizationCommandAdapter
   public Single<OrganizationCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.organization.OrganizationCommand command
   ) {
-    return Single.just(new OrganizationCommand(command.getPayload()));
+    return Single.just(
+      new OrganizationCommand(command.getId(), command.getPayload())
+    );
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommand.java
@@ -29,8 +29,9 @@ public class UserCommand extends CockpitCommand<UserCommandPayload> {
     super(CockpitCommandType.USER_COMMAND);
   }
 
-  public UserCommand(UserCommandPayload payload) {
+  public UserCommand(final String commandId, final UserCommandPayload payload) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommandAdapter.java
@@ -32,6 +32,6 @@ public class UserCommandAdapter
   public Single<UserCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.user.UserCommand command
   ) {
-    return Single.just(new UserCommand(command.getPayload()));
+    return Single.just(new UserCommand(command.getId(), command.getPayload()));
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommand.java
@@ -29,8 +29,12 @@ public class V4ApiCommand extends CockpitCommand<V4ApiCommandPayload> {
     super(CockpitCommandType.V4_API_COMMAND);
   }
 
-  public V4ApiCommand(V4ApiCommandPayload payload) {
+  public V4ApiCommand(
+    final String commandId,
+    final V4ApiCommandPayload payload
+  ) {
     this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommandAdapter.java
@@ -32,6 +32,6 @@ public class V4ApiCommandAdapter
   public Single<V4ApiCommand> adapt(
     final io.gravitee.cockpit.api.command.v1.v4api.V4ApiCommand command
   ) {
-    return Single.just(new V4ApiCommand(command.getPayload()));
+    return Single.just(new V4ApiCommand(command.getId(), command.getPayload()));
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeCommand.java
@@ -17,6 +17,7 @@ package io.gravitee.cockpit.api.command.v1.bridge;
 
 import io.gravitee.cockpit.api.command.v1.CockpitCommand;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.hello.HelloCommandPayload;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -34,6 +35,15 @@ public class BridgeCommand extends CockpitCommand<BridgeCommandPayload> {
 
   public BridgeCommand(final BridgeCommandPayload payload) {
     this();
+    this.payload = payload;
+  }
+
+  public BridgeCommand(
+    final String commandId,
+    final BridgeCommandPayload payload
+  ) {
+    this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeReplyPayload.java
@@ -17,8 +17,11 @@ package io.gravitee.cockpit.api.command.v1.bridge;
 
 import io.gravitee.exchange.api.command.Payload;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.experimental.Accessors;
 
 /**
@@ -28,8 +31,9 @@ import lombok.experimental.Accessors;
 public record BridgeReplyPayload(List<BridgeReplyContent> contents)
   implements Payload {
   @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
   @Data
-  @Accessors(fluent = true)
   public static class BridgeReplyContent implements Payload {
 
     private String installationId;

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/environment/DisableEnvironmentCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/environment/DisableEnvironmentCommand.java
@@ -29,7 +29,9 @@ public class DisableEnvironmentCommand
     super(CockpitCommandType.DISABLE_ENVIRONMENT);
   }
 
-  public DisableEnvironmentCommand(DisableEnvironmentCommandPayload payload) {
+  public DisableEnvironmentCommand(
+    final DisableEnvironmentCommandPayload payload
+  ) {
     this();
     this.payload = payload;
   }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/hello/HelloCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/hello/HelloCommand.java
@@ -33,8 +33,17 @@ public class HelloCommand extends CockpitCommand<HelloCommandPayload> {
     super(CockpitCommandType.HELLO);
   }
 
-  public HelloCommand(HelloCommandPayload payload) {
+  public HelloCommand(final HelloCommandPayload payload) {
     this();
+    this.payload = payload;
+  }
+
+  public HelloCommand(
+    final String commandId,
+    final HelloCommandPayload payload
+  ) {
+    this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/node/NodeCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/node/NodeCommand.java
@@ -17,6 +17,7 @@ package io.gravitee.cockpit.api.command.v1.node;
 
 import io.gravitee.cockpit.api.command.v1.CockpitCommand;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.hello.HelloCommandPayload;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -32,8 +33,14 @@ public class NodeCommand extends CockpitCommand<NodeCommandPayload> {
     super(CockpitCommandType.NODE);
   }
 
-  public NodeCommand(NodeCommandPayload payload) {
+  public NodeCommand(final NodeCommandPayload payload) {
     this();
+    this.payload = payload;
+  }
+
+  public NodeCommand(final String commandId, final NodeCommandPayload payload) {
+    this();
+    this.id = commandId;
     this.payload = payload;
   }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/node/healthcheck/NodeHealthCheckCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/node/healthcheck/NodeHealthCheckCommand.java
@@ -18,6 +18,7 @@ package io.gravitee.cockpit.api.command.v1.node.healthcheck;
 import io.gravitee.cockpit.api.command.v1.CockpitCommand;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommandPayload;
+import io.gravitee.cockpit.api.command.v1.node.NodeCommandPayload;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 
@@ -34,8 +35,17 @@ public class NodeHealthCheckCommand
     super(CockpitCommandType.NODE_HEALTHCHECK);
   }
 
-  public NodeHealthCheckCommand(NodeHealthCheckCommandPayload payload) {
+  public NodeHealthCheckCommand(final NodeHealthCheckCommandPayload payload) {
     this();
+    this.payload = payload;
+  }
+
+  public NodeHealthCheckCommand(
+    final String commandId,
+    final NodeHealthCheckCommandPayload payload
+  ) {
+    this();
+    this.id = commandId;
     this.payload = payload;
   }
 }


### PR DESCRIPTION
When adapting some command, the original command id was lost during the process.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.4-fix-missing-command-id-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.4-fix-missing-command-id-SNAPSHOT/gravitee-cockpit-api-3.0.4-fix-missing-command-id-SNAPSHOT.zip)
  <!-- Version placeholder end -->
