### PR TITLE
fix: add missing empty constructor on legacy command

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommand.java
@@ -26,6 +26,10 @@ import io.gravitee.cockpit.api.command.v1.node.healthcheck.NodeHealthCheckComman
 public class HealthCheckCommand
   extends CockpitCommand<NodeHealthCheckCommandPayload> {
 
+  public HealthCheckCommand() {
+    super(CockpitCommandType.HEALTHCHECK_COMMAND);
+  }
+
   public HealthCheckCommand(final String commandId) {
     super(CockpitCommandType.HEALTHCHECK_COMMAND);
     this.id = commandId;

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommand.java
@@ -21,6 +21,10 @@ import io.gravitee.cockpit.api.command.v1.node.NodeCommandPayload;
 
 public class NodeCommand extends CockpitCommand<NodeCommandPayload> {
 
+  public NodeCommand() {
+    super(CockpitCommandType.NODE_COMMAND);
+  }
+
   public NodeCommand(final String commandId) {
     super(CockpitCommandType.NODE_COMMAND);
     this.id = commandId;


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.7-fix-legacy-serialization-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.7-fix-legacy-serialization-SNAPSHOT/gravitee-cockpit-api-3.0.7-fix-legacy-serialization-SNAPSHOT.zip)
  <!-- Version placeholder end -->
