### PR TITLE
fix: add missing installation id from legacy node command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>7.0.14</gravitee-bom.version>
         <gravitee-node.version>5.12.0</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-exchange.version>1.2.1</gravitee-exchange.version>
+        <gravitee-exchange.version>1.2.3</gravitee-exchange.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeCommandAdapter.java
@@ -32,6 +32,7 @@ public class BridgeCommandAdapter
 
   @Override
   public Single<BridgeCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.bridge.BridgeCommand command
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyCommandAdapter.java
@@ -31,6 +31,7 @@ public class BridgeLegacyCommandAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.bridge.BridgeCommand> adapt(
+    final String targetId,
     final BridgeCommand command
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyMultiReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyMultiReplyAdapter.java
@@ -32,6 +32,7 @@ public class BridgeLegacyMultiReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.bridge.BridgeReply> adapt(
+    final String targetId,
     final BridgeMultiReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacySimpleReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacySimpleReplyAdapter.java
@@ -32,6 +32,7 @@ public class BridgeLegacySimpleReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.bridge.BridgeReply> adapt(
+    final String targetId,
     final BridgeSimpleReply reply
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
@@ -32,6 +32,7 @@ public class BridgeReplyAdapter
 
   @Override
   public Single<BridgeReply> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.bridge.BridgeReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelCommandAdapter.java
@@ -30,6 +30,7 @@ public class DeployModelCommandAdapter
 
   @Override
   public Single<DeployModelCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.designer.DeployModelCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/designer/DeployModelReplyAdapter.java
@@ -31,6 +31,7 @@ public class DeployModelReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.designer.DeployModelReply> adapt(
+    final String targetId,
     final DeployModelReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentCommandAdapter.java
@@ -30,6 +30,7 @@ public class DisableEnvironmentCommandAdapter
 
   @Override
   public Single<DisableEnvironmentCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.environment.DisableEnvironmentCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/DisableEnvironmentReplyAdapter.java
@@ -31,6 +31,7 @@ public class DisableEnvironmentReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.environment.DisableEnvironmentReply> adapt(
+    final String targetId,
     final DisableEnvironmentReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentCommandAdapter.java
@@ -30,6 +30,7 @@ public class EnvironmentCommandAdapter
 
   @Override
   public Single<EnvironmentCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.environment.EnvironmentCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/environment/EnvironmentReplyAdapter.java
@@ -31,6 +31,7 @@ public class EnvironmentReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.environment.EnvironmentReply> adapt(
+    final String targetId,
     final EnvironmentReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckCommandAdapter.java
@@ -30,6 +30,7 @@ public class HealthCheckCommandAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.node.healthcheck.NodeHealthCheckCommand> adapt(
+    final String targetId,
     final HealthCheckCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/healthcheck/HealthCheckReplyAdapter.java
@@ -30,6 +30,7 @@ public class HealthCheckReplyAdapter
 
   @Override
   public Single<HealthCheckReply> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.node.healthcheck.NodeHealthCheckReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloCommandAdapter.java
@@ -31,6 +31,7 @@ public class HelloCommandAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.hello.HelloCommand> adapt(
+    final String targetId,
     final HelloCommand command
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/hello/HelloReplyAdapter.java
@@ -30,6 +30,7 @@ public class HelloReplyAdapter
 
   @Override
   public Single<HelloReply> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.hello.HelloReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationCommandAdapter.java
@@ -30,6 +30,7 @@ public class InstallationCommandAdapter
 
   @Override
   public Single<InstallationCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.installation.InstallationCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/InstallationReplyAdapter.java
@@ -31,6 +31,7 @@ public class InstallationReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.installation.InstallationReply> adapt(
+    final String targetId,
     final InstallationReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationCommandAdapter.java
@@ -30,6 +30,7 @@ public class UnlinkInstallationCommandAdapter
 
   @Override
   public Single<UnlinkInstallationCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.installation.UnlinkInstallationCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/installation/UnlinkInstallationReplyAdapter.java
@@ -31,6 +31,7 @@ public class UnlinkInstallationReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.installation.UnlinkInstallationReply> adapt(
+    final String targetId,
     final UnlinkInstallationReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipCommandAdapter.java
@@ -30,6 +30,7 @@ public class DeleteMembershipCommandAdapter
 
   @Override
   public Single<DeleteMembershipCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.membership.DeleteMembershipCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/DeleteMembershipReplyAdapter.java
@@ -31,6 +31,7 @@ public class DeleteMembershipReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.membership.DeleteMembershipReply> adapt(
+    final String targetId,
     final DeleteMembershipReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipCommandAdapter.java
@@ -30,6 +30,7 @@ public class MembershipCommandAdapter
 
   @Override
   public Single<MembershipCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.membership.MembershipCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/membership/MembershipReplyAdapter.java
@@ -31,6 +31,7 @@ public class MembershipReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.membership.MembershipReply> adapt(
+    final String targetId,
     final MembershipReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeCommandAdapter.java
@@ -30,12 +30,13 @@ public class NodeCommandAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.node.NodeCommand> adapt(
+    final String targetId,
     final NodeCommand command
   ) {
     return Single.just(
       new io.gravitee.cockpit.api.command.v1.node.NodeCommand(
         command.getId(),
-        command.getPayload()
+        command.getPayload().toBuilder().installationId(targetId).build()
       )
     );
   }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/node/NodeReplyAdapter.java
@@ -30,6 +30,7 @@ public class NodeReplyAdapter
 
   @Override
   public Single<NodeReply> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.node.NodeReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationCommandAdapter.java
@@ -30,6 +30,7 @@ public class DisableOrganizationCommandAdapter
 
   @Override
   public Single<DisableOrganizationCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.organization.DisableOrganizationCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/DisableOrganizationReplyAdapter.java
@@ -31,6 +31,7 @@ public class DisableOrganizationReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.organization.DisableOrganizationReply> adapt(
+    final String targetId,
     final DisableOrganizationReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationCommandAdapter.java
@@ -30,6 +30,7 @@ public class OrganizationCommandAdapter
 
   @Override
   public Single<OrganizationCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.organization.OrganizationCommand command
   ) {
     return Single.just(

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/organization/OrganizationReplyAdapter.java
@@ -32,6 +32,7 @@ public class OrganizationReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.organization.OrganizationReply> adapt(
+    final String targetId,
     final OrganizationReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserCommandAdapter.java
@@ -30,6 +30,7 @@ public class UserCommandAdapter
 
   @Override
   public Single<UserCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.user.UserCommand command
   ) {
     return Single.just(new UserCommand(command.getId(), command.getPayload()));

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/user/UserReplyAdapter.java
@@ -32,6 +32,7 @@ public class UserReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.user.UserReply> adapt(
+    final String targetId,
     final UserReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommandAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiCommandAdapter.java
@@ -30,6 +30,7 @@ public class V4ApiCommandAdapter
 
   @Override
   public Single<V4ApiCommand> adapt(
+    final String targetId,
     final io.gravitee.cockpit.api.command.v1.v4api.V4ApiCommand command
   ) {
     return Single.just(new V4ApiCommand(command.getId(), command.getPayload()));

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/v4api/V4ApiReplyAdapter.java
@@ -32,6 +32,7 @@ public class V4ApiReplyAdapter
 
   @Override
   public Single<io.gravitee.cockpit.api.command.v1.v4api.V4ApiReply> adapt(
+    final String targetId,
     final V4ApiReply reply
   ) {
     return Single.fromCallable(() -> {

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/node/NodeCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/node/NodeCommandPayload.java
@@ -23,7 +23,7 @@ import lombok.Builder;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
+@Builder(toBuilder = true)
 public record NodeCommandPayload(
   /*
    * The node ID

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/node/healthcheck/NodeHealthCheckCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/node/healthcheck/NodeHealthCheckCommandPayload.java
@@ -23,7 +23,7 @@ import lombok.Builder;
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Builder
+@Builder(toBuilder = true)
 public record NodeHealthCheckCommandPayload(
   String nodeId,
   String installationId,


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.9-fix-missing-installation-id-node-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.9-fix-missing-installation-id-node-SNAPSHOT/gravitee-cockpit-api-3.0.9-fix-missing-installation-id-node-SNAPSHOT.zip)
  <!-- Version placeholder end -->
