### PR TITLE
fix: create an error simple reply in case of bridge reply in error

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyMultiReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacyMultiReplyAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.cockpit.api.command.legacy.bridge;
 import io.gravitee.cockpit.api.command.legacy.CockpitReplyType;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReply;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReplyPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.ReplyAdapter;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -46,12 +47,13 @@ public class BridgeLegacyMultiReplyAdapter
             .organizationId(bridgeSimpleReply.getOrganizationId())
             .installationId(bridgeSimpleReply.getInstallationId())
             .content(bridgeSimpleReply.getPayloadAsString())
+            .error(bridgeSimpleReply.getCommandStatus() == CommandStatus.ERROR)
             .build()
         )
         .toList();
       return new io.gravitee.cockpit.api.command.v1.bridge.BridgeReply(
         reply.getCommandId(),
-        new BridgeReplyPayload(contents)
+        new BridgeReplyPayload(false, contents)
       );
     });
   }

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacySimpleReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeLegacySimpleReplyAdapter.java
@@ -18,6 +18,7 @@ package io.gravitee.cockpit.api.command.legacy.bridge;
 import io.gravitee.cockpit.api.command.legacy.CockpitReplyType;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReply;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReplyPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.ReplyAdapter;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -39,6 +40,7 @@ public class BridgeLegacySimpleReplyAdapter
       new io.gravitee.cockpit.api.command.v1.bridge.BridgeReply(
         reply.getCommandId(),
         new BridgeReplyPayload(
+          true,
           List.of(
             BridgeReplyPayload.BridgeReplyContent
               .builder()
@@ -46,6 +48,7 @@ public class BridgeLegacySimpleReplyAdapter
               .organizationId(reply.getOrganizationId())
               .installationId(reply.getInstallationId())
               .content(reply.getPayloadAsString())
+              .error(reply.getCommandStatus() == CommandStatus.ERROR)
               .build()
           )
         )

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
@@ -17,6 +17,7 @@ package io.gravitee.cockpit.api.command.legacy.bridge;
 
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
 import io.gravitee.cockpit.api.command.v1.bridge.BridgeReplyPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.ReplyAdapter;
 import io.reactivex.rxjava3.core.Single;
 import java.util.List;
@@ -69,11 +70,17 @@ public class BridgeReplyAdapter
     final io.gravitee.cockpit.api.command.v1.bridge.BridgeReply reply,
     final BridgeReplyPayload.BridgeReplyContent bridgeReplyContent
   ) {
-    BridgeSimpleReply bridgeSimpleReply = new BridgeSimpleReply(
-      reply.getCommandId(),
-      reply.getCommandStatus(),
-      reply.getErrorDetails()
-    );
+    BridgeSimpleReply bridgeSimpleReply;
+    if (bridgeReplyContent.isError()) {
+      bridgeSimpleReply =
+        new BridgeSimpleReply(
+          reply.getCommandId(),
+          CommandStatus.ERROR,
+          "Unable to build to Bridge Reply"
+        );
+    } else {
+      bridgeSimpleReply = new BridgeSimpleReply(reply.getCommandId());
+    }
     bridgeSimpleReply.setInstallationId(bridgeReplyContent.getInstallationId());
     bridgeSimpleReply.setEnvironmentId(bridgeReplyContent.getEnvironmentId());
     bridgeSimpleReply.setOrganizationId(bridgeReplyContent.getOrganizationId());

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeReplyAdapter.java
@@ -38,12 +38,16 @@ public class BridgeReplyAdapter
   ) {
     return Single.fromCallable(() -> {
       BridgeReplyPayload replyPayload = reply.getPayload();
-      if (replyPayload.contents() != null) {
-        if (replyPayload.contents().size() == 1) {
+      if (
+        replyPayload != null &&
+        replyPayload.contents() != null &&
+        !replyPayload.contents().isEmpty()
+      ) {
+        if (replyPayload.singleTarget()) {
           BridgeReplyPayload.BridgeReplyContent bridgeReplyContent =
             replyPayload.contents().get(0);
           return createSimpleReplyFrom(reply, bridgeReplyContent);
-        } else if (replyPayload.contents().size() > 1) {
+        } else {
           List<BridgeSimpleReply> simpleReplies = replyPayload
             .contents()
             .stream()

--- a/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeSimpleReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/legacy/bridge/BridgeSimpleReply.java
@@ -58,6 +58,14 @@ public class BridgeSimpleReply extends BridgeReply {
     this(commandId, commandStatus, null);
   }
 
+  public BridgeSimpleReply(String commandId) {
+    super(
+      CockpitReplyType.BRIDGE_SIMPLE_REPLY,
+      commandId,
+      CommandStatus.SUCCEEDED
+    );
+  }
+
   public BridgeSimpleReply(
     String commandId,
     CommandStatus commandStatus,

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/bridge/BridgeReplyPayload.java
@@ -21,14 +21,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 
 /**
  * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
  * @author GraviteeSource Team
  */
-public record BridgeReplyPayload(List<BridgeReplyContent> contents)
+public record BridgeReplyPayload(
+  boolean singleTarget,
+  List<BridgeReplyContent> contents
+)
   implements Payload {
   @Builder
   @AllArgsConstructor


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.14-handle-simple-in-error-reply-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.14-handle-simple-in-error-reply-SNAPSHOT/gravitee-cockpit-api-3.0.14-handle-simple-in-error-reply-SNAPSHOT.zip)
  <!-- Version placeholder end -->
