### PR TITLE
fix(deps): upgrade gravitee dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <name>Gravitee.io - Cockpit - API</name>
 
     <properties>
-        <gravitee-bom.version>7.0.23</gravitee-bom.version>
-        <gravitee-node.version>5.12.4</gravitee-node.version>
+        <gravitee-bom.version>8.1.0</gravitee-bom.version>
+        <gravitee-node.version>5.18.0</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.5.2</gravitee-exchange.version>
     </properties>


### PR DESCRIPTION
These two upgrades are related and need to be bumped at the same time:

- https://github.com/gravitee-io/gravitee-cockpit-api/pull/164
- https://github.com/gravitee-io/gravitee-cockpit-api/pull/167

Related issue:
https://gravitee.atlassian.net/browse/CJ-1844
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.31-upgrade-gravitee-deps-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.31-upgrade-gravitee-deps-SNAPSHOT/gravitee-cockpit-api-3.0.31-upgrade-gravitee-deps-SNAPSHOT.zip)
  <!-- Version placeholder end -->
