### PR TITLE
fix: bump exchange framework to 1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>8.1.0</gravitee-bom.version>
         <gravitee-node.version>6.0.3</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
-        <gravitee-exchange.version>1.8.0</gravitee-exchange.version>
+        <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Issue

https://gravitee.atlassian.net/browse/ARCHI-391

## Description

See https://github.com/gravitee-io/gravitee-exchange/blob/main/CHANGELOG.md#182-2024-07-26