### PR TITLE
feat: add scoring service request and response command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <gravitee-node.version>6.3.0</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
+        <gravitee-scoring-api.version>0.1.0</gravitee-scoring-api.version>
     </properties>
 
     <dependencyManagement>
@@ -72,6 +73,13 @@
             <groupId>io.gravitee.alert</groupId>
             <artifactId>gravitee-alert-api</artifactId>
             <version>${gravitee-alert-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.scoring</groupId>
+            <artifactId>gravitee-scoring-api</artifactId>
+            <version>${gravitee-scoring-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestCommand.java
@@ -13,28 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.scoring.request;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DISABLE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ScoringRequestCommand
+  extends CockpitCommand<ScoringRequestCommandPayload> {
+
+  public ScoringRequestCommand() {
+    super(CockpitCommandType.SCORING_REQUEST);
+  }
+
+  public ScoringRequestCommand(ScoringRequestCommandPayload payload) {
+    super(CockpitCommandType.SCORING_REQUEST);
+    this.payload = payload;
+  }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestCommandPayload.java
@@ -13,28 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.scoring.request;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DISABLE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-}
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.scoring.api.model.ScoringRequest;
+
+public record ScoringRequestCommandPayload(
+  String correlationId,
+  String organizationId,
+  String environmentId,
+  String installationId,
+  ScoringRequest scoringRequest
+)
+  implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/request/ScoringRequestReply.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.scoring.request;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.exchange.api.command.Payload;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ScoringRequestReply extends CockpitReply<Payload> {
+
+  public ScoringRequestReply() {
+    super(CockpitCommandType.SCORING_REQUEST);
+  }
+
+  public ScoringRequestReply(String commandId, CommandStatus commandStatus) {
+    super(CockpitCommandType.SCORING_REQUEST, commandId, commandStatus);
+  }
+
+  public ScoringRequestReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.SCORING_REQUEST, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseCommand.java
@@ -13,28 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.scoring.response;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DISABLE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ScoringResponseCommand
+  extends CockpitCommand<ScoringResponseCommandPayload> {
+
+  public ScoringResponseCommand() {
+    super(CockpitCommandType.SCORING_RESPONSE);
+  }
+
+  public ScoringResponseCommand(ScoringResponseCommandPayload payload) {
+    super(CockpitCommandType.SCORING_RESPONSE);
+    this.payload = payload;
+  }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseCommandPayload.java
@@ -13,28 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.scoring.response;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DISABLE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-}
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.scoring.api.model.ScoringResult;
+
+public record ScoringResponseCommandPayload(
+  String correlationId,
+  String organizationId,
+  String environmentId,
+  ScoringResult result
+)
+  implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/scoring/response/ScoringResponseReply.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.scoring.response;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.exchange.api.command.Payload;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ScoringResponseReply extends CockpitReply<Payload> {
+
+  public ScoringResponseReply() {
+    super(CockpitCommandType.SCORING_RESPONSE);
+  }
+
+  public ScoringResponseReply(String commandId, CommandStatus commandStatus) {
+    super(CockpitCommandType.SCORING_RESPONSE, commandId, commandStatus);
+  }
+
+  public ScoringResponseReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.SCORING_RESPONSE, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
@@ -16,6 +16,11 @@
 package io.gravitee.cockpit.api.command.websocket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestCommand;
+import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestReply;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommand;
+import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseReply;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
@@ -161,6 +166,14 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.V4_API.name(),
       io.gravitee.cockpit.api.command.v1.v4api.V4ApiCommand.class
     );
+    COMMAND_TYPES.put(
+      CockpitCommandType.SCORING_REQUEST.name(),
+      ScoringRequestCommand.class
+    );
+    COMMAND_TYPES.put(
+      CockpitCommandType.SCORING_RESPONSE.name(),
+      ScoringResponseCommand.class
+    );
 
     // Legacy
     REPLY_TYPES.put(
@@ -288,6 +301,14 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
     REPLY_TYPES.put(
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.V4_API.name(),
       io.gravitee.cockpit.api.command.v1.v4api.V4ApiReply.class
+    );
+    REPLY_TYPES.put(
+      CockpitCommandType.SCORING_REQUEST.name(),
+      ScoringRequestReply.class
+    );
+    REPLY_TYPES.put(
+      CockpitCommandType.SCORING_RESPONSE.name(),
+      ScoringResponseReply.class
     );
   }
 


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5164

**Description**

[ADR](https://gravitee.slab.com/posts/api-scoring-ri6xqojg)

Implement commands to handle Scoring feature in APIM.
- `ScoringRequestCommand` is sent by APIM to trigger the scoring of a list of Assets. Cockpit will forward this request to Scoring providers.
- `ScoringResponseCommand` is sent by Cockpit once it has received and merge responses from Scoring providers.

Pre-requisite: https://github.com/gravitee-io/gravitee-scoring-api/pull/3

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.1.0-apim5164-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.1.0-apim5164-SNAPSHOT/gravitee-cockpit-api-3.1.0-apim5164-SNAPSHOT.zip)
  <!-- Version placeholder end -->
