### PR TITLE
chore(deps): declare gravitee-exchange-api as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
             <groupId>io.gravitee.exchange</groupId>
             <artifactId>gravitee-exchange-api</artifactId>
             <version>${gravitee-exchange.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Reactive dependencies -->


### PR DESCRIPTION
As non provided cause some issue on APIM when the versions of `gravitee-exchange-api` aren't aligned.

https://gravitee.atlassian.net/browse/APIM-6226
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.51`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.0.51/gravitee-cockpit-api-3.0.51.zip)
  <!-- Version placeholder end -->
