### PR TITLE
fix(deps): update gravitee-scoring-api to 0.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-node.version>6.4.3</gravitee-node.version>
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
-        <gravitee-scoring-api.version>0.2.0</gravitee-scoring-api.version>
+        <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.2.3-apim6648-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.2.3-apim6648-SNAPSHOT/gravitee-cockpit-api-3.2.3-apim6648-SNAPSHOT.zip)
  <!-- Version placeholder end -->
