### PR TITLE
feat: SpecGenRequest command api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
+        <gravitee-spec-gen-api.version>1.0.0-feat-SAT-88-SNAPSHOT</gravitee-spec-gen-api.version>
     </properties>
 
     <dependencyManagement>
@@ -80,6 +81,13 @@
             <groupId>io.gravitee.scoring</groupId>
             <artifactId>gravitee-scoring-api</artifactId>
             <version>${gravitee-scoring-api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.gravitee.spec.gen.api</groupId>
+            <artifactId>gravitee-spec-gen-api</artifactId>
+            <version>${gravitee-spec-gen-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
-        <gravitee-spec-gen-api.version>1.0.0-feat-SAT-88-SNAPSHOT</gravitee-spec-gen-api.version>
+        <gravitee-spec-gen-api.version>1.0.0</gravitee-spec-gen-api.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/SpecGenCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/SpecGenCommandPayload.java
@@ -13,32 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.specgen;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-}
+import io.gravitee.exchange.api.command.Payload;
+
+public record SpecGenCommandPayload<T>(
+  String correlationId,
+  String organizationId,
+  String environmentId,
+  String installationId,
+  T payload
+)
+  implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/SpecGenReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/SpecGenReplyPayload.java
@@ -13,32 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.specgen;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-}
+import io.gravitee.exchange.api.command.Payload;
+
+public record SpecGenReplyPayload<T>(T payload) implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.specgen.request;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.specgen.SpecGenCommandPayload;
+import io.gravitee.spec.gen.api.SpecGenRequest;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class SpecGenRequestCommand
+  extends CockpitCommand<SpecGenCommandPayload<SpecGenRequest>> {
+
+  public SpecGenRequestCommand() {
+    super(CockpitCommandType.SPEC_GEN_REQUEST);
+  }
+
+  public SpecGenRequestCommand(SpecGenCommandPayload<SpecGenRequest> payload) {
+    super(CockpitCommandType.SPEC_GEN_REQUEST);
+    this.payload = payload;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestReply.java
@@ -22,8 +22,12 @@ import io.gravitee.exchange.api.command.CommandStatus;
 import io.gravitee.exchange.api.command.Payload;
 import io.gravitee.spec.gen.api.SpecGenRequestState;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 
 @EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
 public class SpecGenRequestReply
   extends CockpitReply<SpecGenReplyPayload<SpecGenRequestState>> {
 

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/request/SpecGenRequestReply.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.specgen.request;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.cockpit.api.command.v1.specgen.SpecGenReplyPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.exchange.api.command.Payload;
+import io.gravitee.spec.gen.api.SpecGenRequestState;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class SpecGenRequestReply
+  extends CockpitReply<SpecGenReplyPayload<SpecGenRequestState>> {
+
+  private SpecGenRequestState requestState;
+
+  public SpecGenRequestReply() {
+    super(CockpitCommandType.SPEC_GEN_REQUEST);
+  }
+
+  public SpecGenRequestReply(
+    String commandId,
+    CommandStatus commandStatus,
+    SpecGenRequestState requestState
+  ) {
+    super(CockpitCommandType.SPEC_GEN_REQUEST, commandId, commandStatus);
+    this.requestState = requestState;
+  }
+
+  public SpecGenRequestReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.SPEC_GEN_REQUEST, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
@@ -21,6 +21,8 @@ import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestCommand;
 import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestReply;
 import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommand;
 import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseReply;
+import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestCommand;
+import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestReply;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
@@ -182,6 +184,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.DELETE_ORGANIZATION.name(),
       io.gravitee.cockpit.api.command.v1.organization.DeleteOrganizationCommand.class
     );
+    COMMAND_TYPES.put(
+      io.gravitee.cockpit.api.command.v1.CockpitCommandType.SPEC_GEN_REQUEST.name(),
+      SpecGenRequestCommand.class
+    );
 
     // Legacy
     REPLY_TYPES.put(
@@ -325,6 +331,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
     REPLY_TYPES.put(
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.DELETE_ORGANIZATION.name(),
       io.gravitee.cockpit.api.command.v1.organization.DeleteOrganizationReply.class
+    );
+    REPLY_TYPES.put(
+      io.gravitee.cockpit.api.command.v1.CockpitCommandType.SPEC_GEN_REQUEST.name(),
+      SpecGenRequestReply.class
     );
   }
 


### PR DESCRIPTION
This PR contains all the necessary commands for spec-gen requests
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.3.0-feat-SAT-77-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.3.0-feat-SAT-77-SNAPSHOT/gravitee-cockpit-api-3.3.0-feat-SAT-77-SNAPSHOT.zip)
  <!-- Version placeholder end -->
