### PR TITLE
feat: spec gen response command and reply

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <gravitee-alert-api.version>2.0.0</gravitee-alert-api.version>
         <gravitee-exchange.version>1.8.2</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.3.0</gravitee-scoring-api.version>
-        <gravitee-spec-gen-api.version>1.0.0</gravitee-spec-gen-api.version>
+        <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/response/SpecGenResponseCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/response/SpecGenResponseCommand.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.specgen.response;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.specgen.SpecGenCommandPayload;
+import io.gravitee.spec.gen.api.SpecGenResponse;
+
+/**
+ * @author Rémi SULTAN (remi.sultan at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public final class SpecGenResponseCommand
+  extends CockpitCommand<SpecGenCommandPayload<SpecGenResponse>> {
+
+  public SpecGenResponseCommand() {
+    super(CockpitCommandType.SPEC_GEN_RESPONSE);
+  }
+
+  public SpecGenResponseCommand(
+    SpecGenCommandPayload<SpecGenResponse> payload
+  ) {
+    super(CockpitCommandType.SPEC_GEN_RESPONSE);
+    this.payload = payload;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/response/SpecGenResponseReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/specgen/response/SpecGenResponseReply.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.specgen.response;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.cockpit.api.command.v1.specgen.SpecGenReplyPayload;
+import io.gravitee.exchange.api.command.CommandStatus;
+import io.gravitee.spec.gen.api.SpecGenRequestState;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+public class SpecGenResponseReply
+  extends CockpitReply<SpecGenReplyPayload<Void>> {
+
+  public SpecGenResponseReply() {
+    super(CockpitCommandType.SPEC_GEN_RESPONSE);
+  }
+
+  public SpecGenResponseReply(String commandId, CommandStatus commandStatus) {
+    super(CockpitCommandType.SPEC_GEN_RESPONSE, commandId, commandStatus);
+  }
+
+  public SpecGenResponseReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.SPEC_GEN_RESPONSE, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
@@ -23,6 +23,8 @@ import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseComman
 import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseReply;
 import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestCommand;
 import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestReply;
+import io.gravitee.cockpit.api.command.v1.specgen.response.SpecGenResponseCommand;
+import io.gravitee.cockpit.api.command.v1.specgen.response.SpecGenResponseReply;
 import io.gravitee.exchange.api.command.Command;
 import io.gravitee.exchange.api.command.Reply;
 import io.gravitee.exchange.api.websocket.command.DefaultExchangeSerDe;
@@ -188,6 +190,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.SPEC_GEN_REQUEST.name(),
       SpecGenRequestCommand.class
     );
+    COMMAND_TYPES.put(
+      CockpitCommandType.SPEC_GEN_RESPONSE.name(),
+      SpecGenResponseCommand.class
+    );
 
     // Legacy
     REPLY_TYPES.put(
@@ -335,6 +341,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
     REPLY_TYPES.put(
       io.gravitee.cockpit.api.command.v1.CockpitCommandType.SPEC_GEN_REQUEST.name(),
       SpecGenRequestReply.class
+    );
+    REPLY_TYPES.put(
+      CockpitCommandType.SPEC_GEN_RESPONSE.name(),
+      SpecGenResponseReply.class
     );
   }
 


### PR DESCRIPTION
Issue:
https://gravitee.atlassian.net/browse/SAT-133

This PR brings interfaces for spec gen command response and reply
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.4.0-feat-SAT-133-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.4.0-feat-SAT-133-SNAPSHOT/gravitee-cockpit-api-3.4.0-feat-SAT-133-SNAPSHOT.zip)
  <!-- Version placeholder end -->
