### PR TITLE
Target token create command and reply

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenCommand.java
@@ -1,4 +1,4 @@
-/*
+package io.gravitee.cockpit.api.command.v1.targettoken;/*
  * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,33 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class TargetTokenCommand
+  extends CockpitCommand<TargetTokenCommandPayload> {
+
+  public TargetTokenCommand() {
+    super(CockpitCommandType.TARGET_TOKEN);
+  }
+
+  public TargetTokenCommand(TargetTokenCommandPayload payload) {
+    this();
+    this.payload = payload;
+  }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenCommandPayload.java
@@ -13,33 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.targettoken;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-}
+import io.gravitee.exchange.api.command.Payload;
+import lombok.Builder;
+
+@Builder
+public record TargetTokenCommandPayload(
+  String id,
+  String organizationId,
+  String environmentId
+)
+  implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenReply.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.targettoken;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@Setter
+public class TargetTokenReply
+  extends CockpitReply<TargetTokenReplyPayload<String>> {
+
+  private String targetToken;
+
+  public TargetTokenReply() {
+    super(CockpitCommandType.TARGET_TOKEN);
+  }
+
+  public TargetTokenReply(
+    String commandId,
+    CommandStatus commandStatus,
+    String targetToken
+  ) {
+    super(CockpitCommandType.TARGET_TOKEN, commandId, commandStatus);
+    this.targetToken = targetToken;
+  }
+
+  public TargetTokenReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.TARGET_TOKEN, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/TargetTokenReplyPayload.java
@@ -13,33 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.targettoken;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-}
+import io.gravitee.exchange.api.command.Payload;
+
+public record TargetTokenReplyPayload<String>(String token)
+  implements Payload {}


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/CJ-2539

Command for target token creation for cloud token

APIM command handler here - https://github.com/gravitee-io/gravitee-api-management/pull/9732
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.5.0-cj-2539-target-token-command-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.5.0-cj-2539-target-token-command-SNAPSHOT/gravitee-cockpit-api-3.5.0-cj-2539-target-token-command-SNAPSHOT.zip)
  <!-- Version placeholder end -->
