### PR TITLE
feat: add Target AccessPoint for Kafka & Tcp gateway

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/model/accesspoint/AccessPoint.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/model/accesspoint/AccessPoint.java
@@ -42,6 +42,8 @@ public class AccessPoint implements Serializable {
     PORTAL,
     PORTAL_API,
     GATEWAY,
+    TCP_GATEWAY,
+    KAFKA_GATEWAY,
   }
 
   public enum Type {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-7134

Add 2 additional tragget types so that APIM can send the template to be completed by cokpit
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.8.0-APIM-7134-kafka-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.8.0-APIM-7134-kafka-SNAPSHOT/gravitee-cockpit-api-3.8.0-APIM-7134-kafka-SNAPSHOT.zip)
  <!-- Version placeholder end -->
