### PR TITLE
feat: add command for expression langage generation

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELCommand.java
@@ -13,34 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.newtai.elgen;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ELCommand extends CockpitCommand<ELCommandPayload> {
+
+  public ELCommand() {
+    super(CockpitCommandType.EL);
+  }
+
+  public ELCommand(ELCommandPayload payload) {
+    this();
+    this.payload = payload;
+  }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELCommandPayload.java
@@ -13,34 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.newtai.elgen;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
+import io.gravitee.exchange.api.command.Payload;
+import java.util.Map;
+
+public record ELCommandPayload(
+  String message,
+  String productVersion,
+  Map<String, String> properties,
+  String installationId
+)
+  implements Payload {
+  public static final String EL_CONTEXT = "elContext";
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELReply.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.newtai.elgen;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+public class ELReply extends CockpitReply<ELReplyPayload> {
+
+  protected ELReply() {
+    super(CockpitCommandType.EL);
+  }
+
+  public ELReply(
+    String commandId,
+    CommandStatus commandStatus,
+    ELReplyPayload elReplyPayload
+  ) {
+    super(CockpitCommandType.EL, commandId, commandStatus);
+    payload = elReplyPayload;
+  }
+
+  public ELReply(String commandId, String errorDetails) {
+    super(CockpitCommandType.EL, commandId, CommandStatus.ERROR);
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/newtai/elgen/ELReplyPayload.java
@@ -13,34 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.newtai.elgen;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
+import io.gravitee.exchange.api.command.Payload;
+
+public record ELReplyPayload(String message, RequestId feedbackId)
+  implements Payload {
+  public record RequestId(
+    String chatId,
+    String userMessageId,
+    String agentMessageId
+  ) {}
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
@@ -17,6 +17,8 @@ package io.gravitee.cockpit.api.command.websocket;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.newtai.elgen.ELCommand;
+import io.gravitee.cockpit.api.command.v1.newtai.elgen.ELReply;
 import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestCommand;
 import io.gravitee.cockpit.api.command.v1.scoring.request.ScoringRequestReply;
 import io.gravitee.cockpit.api.command.v1.scoring.response.ScoringResponseCommand;
@@ -200,6 +202,7 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       CockpitCommandType.TARGET_TOKEN.name(),
       TargetTokenCommand.class
     );
+    COMMAND_TYPES.put(CockpitCommandType.EL.name(), ELCommand.class);
 
     // Legacy
     REPLY_TYPES.put(
@@ -356,6 +359,7 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       CockpitCommandType.TARGET_TOKEN.name(),
       TargetTokenReply.class
     );
+    REPLY_TYPES.put(CockpitCommandType.EL.name(), ELReply.class);
   }
 
   public CockpitExchangeSerDe(final ObjectMapper objectMapper) {


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-9966

Create a new command that allows an expression language to be prompted through the cockpit.

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-9966-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.9.0-apim-9966-SNAPSHOT/gravitee-cockpit-api-3.9.0-apim-9966-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.9.0-apim-9966-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.9.0-apim-9966-SNAPSHOT/gravitee-cockpit-api-3.9.0-apim-9966-SNAPSHOT.zip)
  <!-- Version placeholder end -->
