### PR TITLE
feat: add delete target token command

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenCommand.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenCommand.java
@@ -1,4 +1,4 @@
-/*
+package io.gravitee.cockpit.api.command.v1.targettoken;/*
  * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,36 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DELETE_TARGET_TOKEN,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
-  EL_GEN_FEEDBACK,
+import io.gravitee.cockpit.api.command.v1.CockpitCommand;
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class DeleteTargetTokenCommand
+  extends CockpitCommand<DeleteTargetTokenCommandPayload> {
+
+  public DeleteTargetTokenCommand() {
+    super(CockpitCommandType.DELETE_TARGET_TOKEN);
+  }
+
+  public DeleteTargetTokenCommand(DeleteTargetTokenCommandPayload payload) {
+    this();
+    this.payload = payload;
+  }
 }

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenCommandPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenCommandPayload.java
@@ -13,36 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.targettoken;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DELETE_TARGET_TOKEN,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
-  EL_GEN_FEEDBACK,
-}
+import io.gravitee.exchange.api.command.Payload;
+import lombok.Builder;
+
+@Builder
+public record DeleteTargetTokenCommandPayload(
+  String id,
+  String organizationId,
+  String environmentId
+)
+  implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenReply.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenReply.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.cockpit.api.command.v1.targettoken;
+
+import io.gravitee.cockpit.api.command.v1.CockpitCommandType;
+import io.gravitee.cockpit.api.command.v1.CockpitReply;
+import io.gravitee.exchange.api.command.CommandStatus;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class DeleteTargetTokenReply
+  extends CockpitReply<DeleteTargetTokenReplyPayload> {
+
+  public DeleteTargetTokenReply() {
+    super(CockpitCommandType.DELETE_TARGET_TOKEN);
+  }
+
+  public DeleteTargetTokenReply(String commandId, CommandStatus status) {
+    super(CockpitCommandType.DELETE_TARGET_TOKEN, commandId, status);
+    this.payload = new DeleteTargetTokenReplyPayload();
+  }
+
+  public DeleteTargetTokenReply(String commandId, String errorDetails) {
+    super(
+      CockpitCommandType.DELETE_TARGET_TOKEN,
+      commandId,
+      CommandStatus.ERROR
+    );
+    this.errorDetails = errorDetails;
+  }
+}

--- a/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenReplyPayload.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/v1/targettoken/DeleteTargetTokenReplyPayload.java
@@ -13,36 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.gravitee.cockpit.api.command.v1;
+package io.gravitee.cockpit.api.command.v1.targettoken;
 
-/**
- * @author Guillaume LAMIRAND (guillaume.lamirand at graviteesource.com)
- * @author GraviteeSource Team
- */
-public enum CockpitCommandType {
-  BRIDGE,
-  SCORING_REQUEST,
-  SCORING_RESPONSE,
-  DEPLOY_MODEL,
-  DELETE_MEMBERSHIP,
-  DELETE_ENVIRONMENT,
-  DELETE_ORGANIZATION,
-  DELETE_TARGET_TOKEN,
-  DISABLE_ENVIRONMENT,
-  DISABLE_ORGANIZATION,
-  ENVIRONMENT,
-  HELLO,
-  INSTALLATION,
-  MEMBERSHIP,
-  NODE,
-  NODE_HEALTHCHECK,
-  ORGANIZATION,
-  USER,
-  UNLINK_INSTALLATION,
-  V4_API,
-  SPEC_GEN_REQUEST,
-  SPEC_GEN_RESPONSE,
-  TARGET_TOKEN,
-  EL,
-  EL_GEN_FEEDBACK,
-}
+import io.gravitee.exchange.api.command.Payload;
+
+public record DeleteTargetTokenReplyPayload() implements Payload {}

--- a/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/websocket/CockpitExchangeSerDe.java
@@ -29,6 +29,8 @@ import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestCommand;
 import io.gravitee.cockpit.api.command.v1.specgen.request.SpecGenRequestReply;
 import io.gravitee.cockpit.api.command.v1.specgen.response.SpecGenResponseCommand;
 import io.gravitee.cockpit.api.command.v1.specgen.response.SpecGenResponseReply;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenCommand;
+import io.gravitee.cockpit.api.command.v1.targettoken.DeleteTargetTokenReply;
 import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenCommand;
 import io.gravitee.cockpit.api.command.v1.targettoken.TargetTokenReply;
 import io.gravitee.exchange.api.command.Command;
@@ -204,6 +206,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
       CockpitCommandType.TARGET_TOKEN.name(),
       TargetTokenCommand.class
     );
+    COMMAND_TYPES.put(
+      CockpitCommandType.DELETE_TARGET_TOKEN.name(),
+      DeleteTargetTokenCommand.class
+    );
     COMMAND_TYPES.put(CockpitCommandType.EL.name(), ELCommand.class);
     COMMAND_TYPES.put(
       CockpitCommandType.EL_GEN_FEEDBACK.name(),
@@ -364,6 +370,10 @@ public class CockpitExchangeSerDe extends DefaultExchangeSerDe {
     REPLY_TYPES.put(
       CockpitCommandType.TARGET_TOKEN.name(),
       TargetTokenReply.class
+    );
+    REPLY_TYPES.put(
+      CockpitCommandType.DELETE_TARGET_TOKEN.name(),
+      DeleteTargetTokenReply.class
     );
     REPLY_TYPES.put(CockpitCommandType.EL.name(), ELReply.class);
     REPLY_TYPES.put(


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/CJ-3450

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.11.0-cj-3183-delete-cloud-token-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.11.0-cj-3183-delete-cloud-token-SNAPSHOT/gravitee-cockpit-api-3.11.0-cj-3183-delete-cloud-token-SNAPSHOT.zip)
  <!-- Version placeholder end -->
