### PR TITLE
AM-6611-vertx-5-migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-  gravitee: gravitee-io/gravitee@5.4.2
+  gravitee: gravitee-io/gravitee@6.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,8 @@
     <name>Gravitee.io - Cockpit - API</name>
 
     <properties>
-        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
-        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
         <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.7.1</gravitee-scoring-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.6.0</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <groupId>io.gravitee.cockpit</groupId>
@@ -34,10 +34,10 @@
     <name>Gravitee.io - Cockpit - API</name>
 
     <properties>
-        <gravitee-bom.version>8.3.47</gravitee-bom.version>
-        <gravitee-node.version>7.19.1</gravitee-node.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-node.version>8.0.0-beta.2</gravitee-node.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
-        <gravitee-exchange.version>1.10.0</gravitee-exchange.version>
+        <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.7.1</gravitee-scoring-api.version>
         <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
         <gravitee-node.version>9.0.0-alpha.1</gravitee-node.version>
         <gravitee-alert-api.version>2.1.22</gravitee-alert-api.version>
-        <gravitee-exchange.version>3.0.0-AM-6611-vertx-5-migration-SNAPSHOT</gravitee-exchange.version>
+        <gravitee-exchange.version>3.0.0-alpha.1</gravitee-exchange.version>
         <gravitee-scoring-api.version>0.7.1</gravitee-scoring-api.version>
         <gravitee-spec-gen-api.version>1.1.0</gravitee-spec-gen-api.version>
     </properties>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `4.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/4.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-cockpit-api-4.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
