### PR TITLE
feat: add gamma access points

### DIFF
--- a/src/main/java/io/gravitee/cockpit/api/command/model/accesspoint/AccessPoint.java
+++ b/src/main/java/io/gravitee/cockpit/api/command/model/accesspoint/AccessPoint.java
@@ -44,6 +44,8 @@ public class AccessPoint implements Serializable {
     GATEWAY,
     TCP_GATEWAY,
     KAFKA_GATEWAY,
+    GAMMA_CONSOLE,
+    GAMMA_API,
   }
 
   public enum Type {


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.12.0-gamma-access-point-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/cockpit/gravitee-cockpit-api/3.12.0-gamma-access-point-SNAPSHOT/gravitee-cockpit-api-3.12.0-gamma-access-point-SNAPSHOT.zip)
  <!-- Version placeholder end -->
